### PR TITLE
Do not care the order of net-kourier cut

### DIFF
--- a/RELEASE-LEADS.md
+++ b/RELEASE-LEADS.md
@@ -272,15 +272,13 @@ First:
 - [knative-sandbox/net-contour](https://github.com/knative-sandbox/net-contour)
 - [knative-sandbox/net-http01](https://github.com/knative-sandbox/net-http01)
 - [knative-sandbox/net-istio](https://github.com/knative-sandbox/net-istio)
+- [knative-sandbox/net-kourier](https://github.com/knative-sandbox/net-kourier)
 
 - [knative/eventing](https://github.com/knative/eventing)
 - [knative-sandbox/discovery](https://github.com/knative-sandbox/discovery)
 
 - [knative-sandbox/sample-controller](https://github.com/knative-sandbox/sample-controller)
 
-After **serving**:
-
-- [knative-sandbox/net-kourier](https://github.com/knative-sandbox/net-kourier)
 
 After **eventing**:
 


### PR DESCRIPTION
We don't need to care about cutting the order of net-kourier as it  does not depend
on Serving repo anymore.

Please refer to https://github.com/knative-sandbox/net-kourier/pull/327/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L22

